### PR TITLE
Fixed DeflateEditor compression to use deflate (not gzip)

### DIFF
--- a/src/burp/DeflateEditorTab.java
+++ b/src/burp/DeflateEditorTab.java
@@ -54,10 +54,9 @@ public class DeflateEditorTab extends AbstractDecompressorEditorTab implements I
 	protected byte[] compress(byte[] content) throws IOException {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		DeflaterOutputStream dos = new DeflaterOutputStream(baos);
-		GZIPOutputStream gzos = new GZIPOutputStream(baos);
-		gzos.write(content);
-		gzos.flush();
-		gzos.close();
+		dos.write(content);
+		dos.flush();
+		dos.close();
 		baos.close();
 		return baos.toByteArray();
 	}


### PR DESCRIPTION
The DeflateEditor currently uses the gzip compression and should be using deflate compression. This pull request fixes that.